### PR TITLE
use options to omit header from list_of_lists

### DIFF
--- a/lib/tabular.ex
+++ b/lib/tabular.ex
@@ -41,35 +41,6 @@ defmodule Tabular do
 
   @doc ~S'''
 
-  Converts an ascii table to a list of lists, omitting the header row.
-
-  ## Examples
-
-      iex> ascii_table = """
-      ...> |---------------+--------------------|
-      ...> | name          | dob                |
-      ...> |---------------+--------------------|
-      ...> | Malcolm       | September 20, 2468 |
-      ...> | Reynolds      |                    |
-      ...> |---------------+--------------------|
-      ...> | Zoe Washburne | February 15, 2484  |
-      ...> |---------------+--------------------|
-      ...> """
-      ...> Tabular.to_list_of_lists_no_header(ascii_table)
-      [
-        ["Malcolm Reynolds", "September 20, 2468"],
-        ["Zoe Washburne", "February 15, 2484"]
-      ]
-
-  '''
-  def to_list_of_lists_no_header(ascii_table) do
-    ascii_table
-    |> to_list_of_lists
-    |> Enum.drop(1)
-  end
-
-  @doc ~S'''
-
   Converts an ascii table to a list of lists.
 
   ## Examples
@@ -90,15 +61,22 @@ defmodule Tabular do
         ["Malcolm Reynolds", "September 20, 2468"],
         ["Zoe Washburne", "February 15, 2484"]
       ]
-
+      ...> Tabular.to_list_of_lists(ascii_table, header: false)
+      [
+        ["Malcolm Reynolds", "September 20, 2468"],
+        ["Zoe Washburne", "February 15, 2484"]
+      ]
   '''
-  def to_list_of_lists(ascii_table) do
-    ascii_table
-    |> lines()
-    |> cell_line_groups()
-    |> trimmed_and_grouped_cell_contents()
-    |> folded_cell_contents()
-    |> specials()
+  def to_list_of_lists(ascii_table, opts \\ [header: true]) do
+    rows =
+      ascii_table
+      |> lines()
+      |> cell_line_groups()
+      |> trimmed_and_grouped_cell_contents()
+      |> folded_cell_contents()
+      |> specials()
+
+    if opts[:header], do: rows, else: Enum.drop(rows, 1)
   end
 
   @doc false

--- a/test/tabular_test.exs
+++ b/test/tabular_test.exs
@@ -111,10 +111,8 @@ defmodule TabularTest do
 
       assert actual == expected
     end
-  end
 
-  describe "to_list_of_lists_no_header" do
-    test "returns values as a list of lists without the header" do
+    test "with header: false, returns values as a lists of lists without the header" do
       data_as_table = """
             +-----------+--------------------+--------------+
             | name      | dob                | predictable? |
@@ -132,7 +130,7 @@ defmodule TabularTest do
             +-----------+--------------------+--------------+
       """
 
-      actual = Tabular.to_list_of_lists_no_header(data_as_table)
+      actual = Tabular.to_list_of_lists(data_as_table, header: false)
 
       expected = [
         ["Malcolm Reynolds", "September 20, 2468", false],


### PR DESCRIPTION
This PR allows passing of a `:header` option to include or exclude headers from a list of lists, instead of having a separate function to do so.